### PR TITLE
Rollback change in default value for max_write_delay config

### DIFF
--- a/src/global_changes_server.erl
+++ b/src/global_changes_server.erl
@@ -54,7 +54,7 @@ init([]) ->
     {ok, Handler} = global_changes_listener:start(),
     % get configs as strings
     UpdateDb0 = config:get("global_changes", "update_db", "true"),
-    MaxWriteDelay0 = config:get("global_changes", "max_write_delay", "25"),
+    MaxWriteDelay0 = config:get("global_changes", "max_write_delay", "500"),
 
     % make config strings into other data types
     UpdateDb = case UpdateDb0 of "false" -> false; _ -> true end,


### PR DESCRIPTION
The default for `global_change:max_write_delay` config was changed from
500 to 25 and is causing performance regression. Reverting this change
back to 500 is resulting in improved performance.

COUCHDB-3304